### PR TITLE
Feature/instance rework

### DIFF
--- a/annotations/src/main/java/org/firezenk/kartographer/annotations/RoutableView.kt
+++ b/annotations/src/main/java/org/firezenk/kartographer/annotations/RoutableView.kt
@@ -1,7 +1,5 @@
 package org.firezenk.kartographer.annotations
 
-import kotlin.reflect.KClass
-
 /**
  * Project: Kartographer
  *
@@ -16,11 +14,6 @@ annotation class RoutableView(
          * @return the path string
          */
         val path: String = "",
-        /**
-         * Possible "bundle" extras
-         * @return array class types for the params
-         */
-        val params: Array<KClass<*>> = arrayOf(),
         /**
          * Define the request code for the activity
          * @return the request code, -1 if not needed

--- a/library/src/main/java/org/firezenk/kartographer/library/IKartographer.kt
+++ b/library/src/main/java/org/firezenk/kartographer/library/IKartographer.kt
@@ -37,7 +37,15 @@ interface IKartographer {
      * @param route The target route
      * @param params The parameters to replace the original ones
      */
-    fun <B> next(route: Route<B>, replacementParams: Array<B>): Boolean
+    fun <B> next(route: Route<B>, replacementParams: B): Boolean
+
+    /**
+     * Navigate to the next route
+     *
+     * @param route The target route
+     * @param params The parameters to replace the original ones
+     */
+    fun next(route: Route<Any>, replacementParams: Map<String, Any>): Boolean
 
     /**
      * Navigate to the last known route on the specified path
@@ -95,11 +103,11 @@ interface IKartographer {
     fun <B> current(): Route<B>?
 
     /**
-     * Obtains the payload of the current route
+     * Obtains the value of the key inside payloads current route
      *
      * @return The payload with specified type
      */
-    fun <B> payload(): B?
+    fun <T> payload(key: String): T?
 
     /**
      * Clear navigation history

--- a/library/src/main/java/org/firezenk/kartographer/library/Route.kt
+++ b/library/src/main/java/org/firezenk/kartographer/library/Route.kt
@@ -13,7 +13,7 @@ class Route<B> (val clazz: Class<*>, val params: Any, var viewParent: Any?, val 
 
     val uuid: UUID = UUID.randomUUID()
     var bundle: B? = null
-    var internalParams: Array<Any>? = null
+    var internalParams: Map<String, Any>? = null
     var path: Path?
 
     init {
@@ -35,7 +35,8 @@ class Route<B> (val clazz: Class<*>, val params: Any, var viewParent: Any?, val 
     @Suppress("UNCHECKED_CAST")
     private fun saveParams(params: Any) {
         try {
-            internalParams = params as Array<Any>
+            internalParams = params as Map<String, Any>
+            internalParams?.plus("uuid" to uuid)
         } catch (ex: ClassCastException) {
             bundle = params as B
         }
@@ -52,9 +53,11 @@ class Route<B> (val clazz: Class<*>, val params: Any, var viewParent: Any?, val 
         result = 31 * result + forResult
         result = 31 * result + uuid.hashCode()
         result = 31 * result + (bundle?.hashCode() ?: 0)
-        result = 31 * result + (internalParams?.let { Arrays.hashCode(it) } ?: 0)
+        result = 31 * result + (internalParams?.let { Arrays.hashCode(it.values.toTypedArray()) } ?: 0)
         return result
     }
 
-    fun <B> copy(replacementParams: Array<B>) = Route<B>(clazz, replacementParams, viewParent, animation, forResult)
+    fun <B> copy(replacementParams: B) = Route<B>(clazz, replacementParams as Any, viewParent, animation, forResult)
+
+    fun copy(replacementParams: Map<String, Any>) = Route<Any>(clazz, replacementParams, viewParent, animation, forResult)
 }

--- a/library/src/main/java/org/firezenk/kartographer/library/dsl/RouteDsl.kt
+++ b/library/src/main/java/org/firezenk/kartographer/library/dsl/RouteDsl.kt
@@ -10,7 +10,7 @@ class RouteDsl<B> {
     class RouteBuilder<B> {
 
         var target: KClass<*>? = null
-        var params: Array<Any>? = arrayOf()
+        var params: Map<String, Any>? = mapOf<String, Any>()
         var anchor: Any? = null
         var animation: RouteAnimation? = null
         var forResult: Int = -1

--- a/processor/src/main/java/org/firezenk/kartographer/processor/RouteProcessor.kt
+++ b/processor/src/main/java/org/firezenk/kartographer/processor/RouteProcessor.kt
@@ -145,13 +145,8 @@ class RouteProcessor : AbstractProcessor() {
                     "      throw org.firezenk.kartographer.processor.exceptions.ParameterNotFoundException(\"Need a view parent or is not a ViewGroup\")\n" +
                     "  }\n")
 
-            if (params.isNotEmpty()) {
-                sb.append("  val next: android.view.View = ${typeElement.simpleName}.newInstance(context as android.content.Context, uuid${this.parametersToString(params)})\n")
-            } else {
-                sb.append("  val next: android.view.View = ${typeElement.simpleName}.newInstance(context as android.content.Context, uuid)\n")
-            }
-
             sb.append("" +
+                    "  val next: android.view.View = ${typeElement.simpleName}(context as android.content.Context)\n" +
                     "  val prev: android.view.View? = viewParent.getChildAt(viewParent.childCount - 1)\n\n" +
                     "  animation?.let {\n" +
                     "    prev?.let {\n" +

--- a/processor/src/main/java/org/firezenk/kartographer/processor/RouteProcessor.kt
+++ b/processor/src/main/java/org/firezenk/kartographer/processor/RouteProcessor.kt
@@ -102,24 +102,26 @@ class RouteProcessor : AbstractProcessor() {
             params = getParameters(typeElement.getAnnotation(RoutableActivity::class.java))
         } else {
             requestCode = getForResult(typeElement.getAnnotation(RoutableView::class.java))
-            params = getParameters(typeElement.getAnnotation(RoutableView::class.java))
+            params = null
         }
 
         val sb = StringBuilder()
 
-        sb.append("" +
-                "  if (parameters.size < ${params?.size}) {\n" +
-                "      throw org.firezenk.kartographer.processor.exceptions.NotEnoughParametersException(\"Need ${params?.size} params\")\n" +
-                "  }\n")
-
-        for ((i, tm) in params!!.withIndex()) {
+        params?.let {
             sb.append("" +
-                    "  if (!(parameters[$i] is ${typeMirrorToString(tm)})) {\n" +
-                    "      throw org.firezenk.kartographer.processor.exceptions.ParameterNotFoundException(\"Need $tm\")\n" +
+                    "  if (parameters.size < ${params.size}) {\n" +
+                    "      throw org.firezenk.kartographer.processor.exceptions.NotEnoughParametersException(\"Need ${params.size} params\")\n" +
                     "  }\n")
-        }
 
-        sb.append("\n")
+            for ((i, tm) in params.withIndex()) {
+                sb.append("" +
+                        "  if (!(parameters[$i] is ${typeMirrorToString(tm)})) {\n" +
+                        "      throw org.firezenk.kartographer.processor.exceptions.ParameterNotFoundException(\"Need $tm\")\n" +
+                        "  }\n")
+            }
+
+            sb.append("\n")
+        }
 
         if (isActivity) {
             sb.append("  val intent: android.content.Intent = android.content.Intent(context as android.content.Context, " + typeElement.simpleName + "::class.java)\n")
@@ -127,8 +129,10 @@ class RouteProcessor : AbstractProcessor() {
             sb.append("  val bundle: android.os.Bundle = android.os.Bundle()\n\n")
             sb.append("  bundle.putString(\"uuid\", uuid.toString())\n")
 
-            if (params.isNotEmpty()) {
-                sb.append(this.parametersToBundle(params))
+            params?.let {
+                if (params.isNotEmpty()) {
+                    sb.append(this.parametersToBundle(params))
+                }
             }
 
             sb.append("  intent.putExtras(bundle)\n")
@@ -289,16 +293,6 @@ class RouteProcessor : AbstractProcessor() {
     }
 
     private fun getParameters(annotation: RoutableActivity): List<TypeMirror>? {
-        try {
-            annotation.params // TODO get forResult
-        } catch (e: MirroredTypesException) {
-            return e.typeMirrors as List<TypeMirror>
-        }
-
-        return null
-    }
-
-    private fun getParameters(annotation: RoutableView): List<TypeMirror>? {
         try {
             annotation.params // TODO get forResult
         } catch (e: MirroredTypesException) {

--- a/sample/src/main/java/org/firezenk/kartographer/MainActivity.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/MainActivity.kt
@@ -76,7 +76,7 @@ class MainActivity : AppCompatActivity(), BottomNavigationView.OnNavigationItemS
     private fun defineRoutes() {
         page1Route = route<Any> {
             target = Page1Route::class
-            params = mapOf("counter" to 0)
+            params = mapOf("part" to "", "counter" to 0)
             anchor = viewHolder
         }
 

--- a/sample/src/main/java/org/firezenk/kartographer/MainActivity.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/MainActivity.kt
@@ -10,9 +10,9 @@ import org.firezenk.kartographer.library.Kartographer
 import org.firezenk.kartographer.library.Path
 import org.firezenk.kartographer.library.Route
 import org.firezenk.kartographer.library.dsl.route
-import org.firezenk.kartographer.pages.Page1Route
-import org.firezenk.kartographer.pages.Page3Route
+import org.firezenk.kartographer.pages.page1.Page1Route
 import org.firezenk.kartographer.pages.page2.Page2Route
+import org.firezenk.kartographer.pages.page3.Page3Route
 import javax.inject.Inject
 
 /**
@@ -76,19 +76,19 @@ class MainActivity : AppCompatActivity(), BottomNavigationView.OnNavigationItemS
     private fun defineRoutes() {
         page1Route = route<Any> {
             target = Page1Route::class
-            params = arrayOf("", 0)
+            params = mapOf("counter" to 0)
             anchor = viewHolder
         }
 
         page2Route = route<Any> {
             target = Page2Route::class
-            params = arrayOf(10)
+            params = mapOf("counter" to 10)
             anchor = viewHolder
         }
 
         page3Route = route<Any> {
             target = Page3Route::class
-            params = arrayOf(100)
+            params = mapOf("counter" to 100)
             anchor = viewHolder
         }
     }

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page1/Page1.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page1/Page1.kt
@@ -10,7 +10,6 @@ import org.firezenk.kartographer.animations.CrossFade
 import org.firezenk.kartographer.annotations.RoutableView
 import org.firezenk.kartographer.library.Kartographer
 import org.firezenk.kartographer.library.dsl.route
-import java.util.*
 import javax.inject.Inject
 
 /**
@@ -19,28 +18,19 @@ import javax.inject.Inject
  * Created by Jorge Garrido Oval, aka firezenk on 14/12/17.
  * Copyright © Jorge Garrido Oval 2017
  */
-@RoutableView(path = "PAGE1", params = [(String::class), (Int::class)])
+@RoutableView(path = "PAGE1")
 class Page1(context: Context?) : FrameLayout(context) {
 
     @Inject lateinit var router: Kartographer
-
-    private var part : String = ""
-    private var counter : Int = 0
-
-    companion object {
-        fun newInstance(context: Context, uuid: UUID, part: String, counter: Int): Page1 {
-            val view = Page1(context)
-            view.part = part
-            view.counter = counter
-            return view
-        }
-    }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         View.inflate(context, R.layout.page_view, this)
 
         SampleApplication.component.injectTo(this)
+
+        var part: String = router.payload<String>("part")!!
+        var counter: Int = router.payload<Int>("counter")!!
 
         part += " -> " + ++counter
         text2.text = context.getString(R.string.route, Page1Route.PATH, part)

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page1/Page1.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page1/Page1.kt
@@ -10,7 +10,6 @@ import org.firezenk.kartographer.animations.CrossFade
 import org.firezenk.kartographer.annotations.RoutableView
 import org.firezenk.kartographer.library.Kartographer
 import org.firezenk.kartographer.library.dsl.route
-import org.firezenk.kartographer.pages.Page1Route
 import java.util.*
 import javax.inject.Inject
 
@@ -52,7 +51,7 @@ class Page1(context: Context?) : FrameLayout(context) {
                 anchor = parent
                 animation = CrossFade()
             }
-            router.next<Any>(route, arrayOf(part, counter))
+            router.next(route, mapOf("part" to part, "counter" to counter))
         }
     }
 }

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2.kt
@@ -22,8 +22,6 @@ class Page2 : Fragment() {
 
     @Inject lateinit var router: Kartographer
 
-    private var counter : Int = 0
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return View.inflate(context, R.layout.page_view, null)
     }
@@ -31,7 +29,7 @@ class Page2 : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        counter = arguments!!.getInt("counter")
+        val counter = arguments!!.getInt("counter")
 
         SampleApplication.component.injectTo(this)
 

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2.kt
@@ -52,7 +52,7 @@ class Page2 : Fragment() {
         text2.setOnClickListener {
             router next route<Any> {
                 target = Page2Route::class
-                params = arrayOf(counter+10)
+                params = mapOf("counter" to counter + 10)
                 anchor = getView()!!.parent
             }
         }

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2.kt
@@ -1,6 +1,5 @@
 package org.firezenk.kartographer.pages.page2
 
-import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
@@ -11,7 +10,6 @@ import org.firezenk.kartographer.R
 import org.firezenk.kartographer.SampleApplication
 import org.firezenk.kartographer.library.Kartographer
 import org.firezenk.kartographer.library.dsl.route
-import java.util.*
 import javax.inject.Inject
 
 /**
@@ -25,16 +23,6 @@ class Page2 : Fragment() {
     @Inject lateinit var router: Kartographer
 
     private var counter : Int = 0
-
-    companion object {
-        fun newInstance(context: Context, uuid: UUID, counter: Int): Page2 {
-            val fragment = Page2()
-            val bundle = Bundle()
-            bundle.putInt("counter", counter)
-            fragment.arguments = bundle
-            return fragment
-        }
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return View.inflate(context, R.layout.page_view, null)

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2Route.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page2/Page2Route.kt
@@ -1,6 +1,6 @@
 package org.firezenk.kartographer.pages.page2
 
-import android.content.Context
+import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import org.firezenk.kartographer.annotations.RouteAnimation
 import org.firezenk.kartographer.processor.interfaces.Routable
@@ -29,9 +29,15 @@ class Page2Route : Routable {
 
         viewParent.removeAllViews()
 
+        val fragment = Page2()
+        val bundle = Bundle()
+
+        bundle.putInt("counter", parameters[0] as Int)
+        fragment.arguments = bundle
+
         val fm = (viewParent.context as AppCompatActivity).supportFragmentManager
         val ft = fm.beginTransaction()
-        ft.add(viewParent.id, Page2.newInstance(context as Context, UUID.randomUUID(), parameters[0] as Int), PATH)
+        ft.add(viewParent.id, fragment, PATH)
         ft.commit()
     }
 

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page3/Page3.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page3/Page3.kt
@@ -11,7 +11,6 @@ import org.firezenk.kartographer.animations.PushLeft
 import org.firezenk.kartographer.annotations.RoutableView
 import org.firezenk.kartographer.library.Kartographer
 import org.firezenk.kartographer.library.dsl.route
-import org.firezenk.kartographer.pages.Page3Route
 import java.util.*
 import javax.inject.Inject
 
@@ -37,14 +36,14 @@ class Page3(context: Context?) : FrameLayout(context) {
 
         SampleApplication.component.injectTo(this)
 
-        val counter = router.payload<Array<Any>>()!![0] as Int
+        val counter: Int? = router.payload<Int>("counter")
 
         text2.text = "${Page3Route.PATH}: $counter"
 
         setOnClickListener {
             router next route<Any> {
                 target = Page3Route::class
-                params = arrayOf(counter + 100)
+                params = mapOf("counter" to counter!! + 100)
                 anchor = parent
                 animation = PushLeft(100)
             }

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page3/Page3.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page3/Page3.kt
@@ -1,6 +1,5 @@
 package org.firezenk.kartographer.pages.page3
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import android.widget.FrameLayout
@@ -11,7 +10,6 @@ import org.firezenk.kartographer.animations.PushLeft
 import org.firezenk.kartographer.annotations.RoutableView
 import org.firezenk.kartographer.library.Kartographer
 import org.firezenk.kartographer.library.dsl.route
-import java.util.*
 import javax.inject.Inject
 
 /**
@@ -20,16 +18,11 @@ import javax.inject.Inject
  * Created by Jorge Garrido Oval, aka firezenk on 14/12/17.
  * Copyright © Jorge Garrido Oval 2017
  */
-@RoutableView(path = "PAGE3", params = [(Int::class)])
+@RoutableView(path = "PAGE3")
 class Page3(context: Context?) : FrameLayout(context) {
 
     @Inject lateinit var router: Kartographer
 
-    companion object {
-        fun newInstance(context: Context, uuid: UUID, counter: Int) = Page3(context)
-    }
-
-    @SuppressLint("SetTextI18n")
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         View.inflate(context, R.layout.page_view, this)


### PR DESCRIPTION
Now we can easily access route parameters from is view using `router.payload()`:

```kotlin
val counter: Int? = router.payload<Int>("counter")
```
Also now is not necessary to set the params on the annotation and also the mandatory `newInstance` method is not needed anymore

See: [implementation sample](https://github.com/FireZenk/Kartographer/blob/1c865880223384419966a39a60fd4a2d52263e2d/sample/src/main/java/org/firezenk/kartographer/pages/page3/Page3.kt)