### PR TITLE
External intents

### DIFF
--- a/library/src/main/java/org/firezenk/kartographer/library/Routable.kt
+++ b/library/src/main/java/org/firezenk/kartographer/library/Routable.kt
@@ -11,10 +11,16 @@ import java.util.*
  * Created by Jorge Garrido Oval, aka firezenk on 20/09/17.
  * Copyright © Jorge Garrido Oval 2017
  */
-interface Routable<B> {
+interface ContextRoutable<B> {
 
     @Throws(ParameterNotFoundException::class, NotEnoughParametersException::class)
     fun route(context: Any, uuid: UUID, parameters: B, viewParent: Any?, animation: RouteAnimation?)
 
     fun path(): String
+}
+
+interface ExternalRoutable {
+
+    @Throws(ParameterNotFoundException::class, NotEnoughParametersException::class)
+    fun route(context: Any, uuid: UUID, parameters: Any? = null)
 }

--- a/library/src/main/java/org/firezenk/kartographer/library/core/Move.kt
+++ b/library/src/main/java/org/firezenk/kartographer/library/core/Move.kt
@@ -1,8 +1,10 @@
 package org.firezenk.kartographer.library.core
 
-import org.firezenk.kartographer.library.Routable
+import org.firezenk.kartographer.library.ContextRoutable
+import org.firezenk.kartographer.library.ExternalRoutable
 import org.firezenk.kartographer.library.dsl.route
 import org.firezenk.kartographer.library.types.*
+import org.firezenk.kartographer.processor.interfaces.Routable as GeneratedRoutable
 
 /**
  * Project: Kartographer
@@ -43,8 +45,7 @@ class Move(private val core: Core) {
 
     private fun routeTo(route: ExternalRoute): Boolean = try {
         logRoute(route)
-
-        //TODO (route.clazz as Routable<*>).route(core.context, route.uuid, Any(), null, null)
+        (route.clazz as ExternalRoutable).route(core.context, route.uuid)
         true
     } catch (e: Throwable) {
         handleError(e)
@@ -90,10 +91,10 @@ class Move(private val core: Core) {
 
     @Suppress("UNCHECKED_CAST")
     private fun <B> createView(route: ContextRoute<B>) = try {
-        (route.clazz as Routable<B>)
+        (route.clazz as ContextRoutable<B>)
                 .route(core.context, route.uuid, route.bundle as B, null, null)
     } catch (e: ClassCastException) {
-        (route.clazz as org.firezenk.kartographer.processor.interfaces.Routable)
+        (route.clazz as GeneratedRoutable)
                 .route(core.context, route.uuid, route.bundle!!, null, null)
     }
 

--- a/library/src/main/java/org/firezenk/kartographer/library/dsl/RouteDsl.kt
+++ b/library/src/main/java/org/firezenk/kartographer/library/dsl/RouteDsl.kt
@@ -19,7 +19,7 @@ class RouteDsl {
 
     class RouteBuilder {
 
-        var target: Any? = null
+        lateinit var target: Any
         var params: Map<String, Any>? = mapOf<String, Any>()
         var path: Path? = null
         var anchor: Any? = null
@@ -35,13 +35,13 @@ class RouteDsl {
             } else ROOT_NODE
         }
 
-        fun build(): ViewRoute = ViewRoute(target!!, params ?: mapOf(), path ?: calculatedPath, anchor!!,
+        fun build(): ViewRoute = ViewRoute(target, params ?: mapOf(), path ?: calculatedPath, anchor!!,
                 animation, forResult)
     }
 
     class RouteActivityBuilder<B> {
 
-        var target: Any? = null
+        lateinit var target: Any
         var params: B? = null
         var path: Path? = null
         var forResult: Int = -1
@@ -55,13 +55,13 @@ class RouteDsl {
             } else ROOT_NODE
         }
 
-        fun build(): ContextRoute<B> = ContextRoute<B>(target!!, params!!, path ?: calculatedPath, forResult)
+        fun build(): ContextRoute<B> = ContextRoute<B>(target, params!!, path ?: calculatedPath, forResult)
     }
 
     class RouteExternalBuilder {
 
-        var target: Any? = null
+        lateinit var target: Any
 
-        fun build(): ExternalRoute = ExternalRoute(target!!)
+        fun build(): ExternalRoute = ExternalRoute(target)
     }
 }

--- a/library/src/test/java/org/firezenk/kartographer/library/core/util/TargetBundleRoute.kt
+++ b/library/src/test/java/org/firezenk/kartographer/library/core/util/TargetBundleRoute.kt
@@ -1,11 +1,11 @@
 package org.firezenk.kartographer.library.core.util
 
 import org.firezenk.kartographer.annotations.RouteAnimation
-import org.firezenk.kartographer.library.Routable
+import org.firezenk.kartographer.library.ContextRoutable
 import org.firezenk.kartographer.library.core.Core
 import java.util.*
 
-class TargetBundleRoute : Routable<Any> {
+class TargetBundleRoute : ContextRoutable<Any> {
     override fun path() = Core.ROOT_NODE.toString()
 
     override fun route(context: Any, uuid: UUID, parameters: Any, viewParent: Any?, animation: RouteAnimation?) {}

--- a/sample/src/main/java/org/firezenk/kartographer/ExternalRoute.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/ExternalRoute.kt
@@ -1,0 +1,38 @@
+package org.firezenk.kartographer
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import org.firezenk.kartographer.library.ExternalRoutable
+import java.util.*
+
+class ExternalRoute : ExternalRoutable {
+
+    companion object {
+        // Google play http market address
+        private val MARKET_GOOGLE_PLAY = "market://details?id="
+        // Google play http address
+        private val URL_HTTP_GOOGLE_PLAY = "https://play.google.com/store/apps/details?id="
+    }
+
+    override fun route(context: Any, uuid: UUID, parameters: Any?) {
+        if (context is Context) {
+            val packageName = context.packageName
+            try {
+                launchUri(context, Uri.parse(MARKET_GOOGLE_PLAY + packageName))
+            } catch (_: ActivityNotFoundException) {
+                launchUri(context, Uri.parse(URL_HTTP_GOOGLE_PLAY + packageName))
+            }
+        }
+    }
+
+    private fun launchUri(context: Context, uri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW, uri)
+        if (context !is Activity) {
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(intent)
+    }
+}

--- a/sample/src/main/java/org/firezenk/kartographer/pages/page4/Page4Activity.kt
+++ b/sample/src/main/java/org/firezenk/kartographer/pages/page4/Page4Activity.kt
@@ -2,10 +2,13 @@ package org.firezenk.kartographer.pages.page4
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import kotlinx.android.synthetic.main.activity_page4.*
+import org.firezenk.kartographer.ExternalRoute
 import org.firezenk.kartographer.R
 import org.firezenk.kartographer.SampleApplication
 import org.firezenk.kartographer.annotations.RoutableActivity
 import org.firezenk.kartographer.library.Kartographer
+import org.firezenk.kartographer.library.dsl.routeExternal
 import javax.inject.Inject
 
 @RoutableActivity("PAGE4")
@@ -20,6 +23,12 @@ class Page4Activity : AppCompatActivity() {
         SampleApplication.component.injectTo(this)
 
         val param = router.bundle<Bundle>()?.getInt("TESTINT")
+
+        button.setOnClickListener {
+            router next routeExternal {
+                target = ExternalRoute()
+            }
+        }
     }
 
 }

--- a/sample/src/main/res/layout/activity_page4.xml
+++ b/sample/src/main/res/layout/activity_page4.xml
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:textSize="63dp"
-    android:text="Hi" />
+    android:orientation="vertical"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="63dp"
+        android:text="Hi" />
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Open external source"/>
+
+</LinearLayout>


### PR DESCRIPTION
closes #17 

Adds the ability to run any external route by implementing a little interface

Sample usage:
```kotlin
kartographer next routeExternal {
    target = ExternalRoute()
}
```

Implementation by extend: 
```kotlin
interface ExternalRoutable {

    @Throws(ParameterNotFoundException::class, NotEnoughParametersException::class)
    fun route(context: Any, uuid: UUID, parameters: Any? = null)
}
```